### PR TITLE
fix: Sort imports in test files to pass ruff linting

### DIFF
--- a/tests/test_flexible_baseline.py
+++ b/tests/test_flexible_baseline.py
@@ -3,6 +3,7 @@
 import numpy as np
 from hypothesis import given, settings
 from hypothesis import strategies as st
+
 from hypothesis_lightcurves.generators import baseline_lightcurves
 from hypothesis_lightcurves.models import Lightcurve
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -2,13 +2,14 @@
 
 import numpy as np
 from hypothesis import given, note
+from numpy import testing as npt
+
 from hypothesis_lightcurves.generators import (
     lightcurves,
     periodic_lightcurves,
     transient_lightcurves,
 )
 from hypothesis_lightcurves.models import Lightcurve
-from numpy import testing as npt
 
 
 class TestBasicLightcurveGenerator:

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -3,6 +3,7 @@
 import numpy as np
 from hypothesis import given, settings
 from hypothesis import strategies as st
+
 from hypothesis_lightcurves.generators import baseline_lightcurves, modified_lightcurves
 from hypothesis_lightcurves.models import Lightcurve
 from hypothesis_lightcurves.modifiers import (


### PR DESCRIPTION
## Summary
- Fixed import sorting issues in three test files (`test_flexible_baseline.py`, `test_generators.py`, `test_modifiers.py`)
- Imports now comply with ruff's I001 rule
- Organized imports with blank lines separating stdlib/third-party from local packages

## Test plan
- [x] Run `nox -s quality` to verify all linting passes
- [x] Run `nox -s tests` to ensure no test regressions
- [x] Verify pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)